### PR TITLE
Use a real name in the license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Lennard94
+Copyright (c) 2020 Lennard Boeselt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi @Lennard94 : it's much better to put a real name than a github handle in the copyright statement.